### PR TITLE
Valid now conforms to protocol

### DIFF
--- a/PTFramework/Classes/Objc /ValidationProtocol.h
+++ b/PTFramework/Classes/Objc /ValidationProtocol.h
@@ -12,6 +12,6 @@
 @required
 - (BOOL)signInValidation:(NSString*) email :(NSString*) password;
 - (BOOL)signUpValidation:(NSString*) email :(NSString*) password :(NSString*) conPassword;
-- (BOOL)validateEmail: (NSString*) email;
+- (BOOL)checkEmail: (NSString*) email;
 @end
 


### PR DESCRIPTION
### Valid now conforms to protocol

Small change to make sure that valid conforms to the validation protocol. 